### PR TITLE
ボットがメッセージ送信時にメンションしないように設定

### DIFF
--- a/src/discordbot/main.py
+++ b/src/discordbot/main.py
@@ -4,9 +4,15 @@ from discord.ext import commands
 from datetime import datetime, timedelta
 import platform
 
+allowed_mentions = discord.AllowedMentions(
+    everyone=False,
+    users=False,
+    roles=False
+)
 
 bot = commands.Bot(
-    command_prefix='d:'
+    command_prefix='d:',
+    allowed_mentions=allowed_mentions
 )
 
 # 登録ボットデータ key=追加された時のmessage.id value=ボット名


### PR DESCRIPTION
resolve: #20 

登録時などメッセージ送信時にメンションしてしまうのを防ぐために、bot全体にメンション制限をかけた。