### PR TITLE
[Bugfix] mainへのPush時にActionsがエラー吐くのを訂正

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,7 +1,5 @@
 name: Flake8 Lint
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
close #19 

## 原因

Lintlyはプルリクに対してコメントするので発火条件がプルリクでないとコメントできない．

## 対処

動作検証はしていない(できない)ですが該当部分を削除しました
